### PR TITLE
chore!: increase minimum required version of node from 12 to 14

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
 	env: {
-		es2021: true,
+		es2020: true,
 		node: true,
 	},
 	extends: [
@@ -12,6 +12,7 @@ module.exports = {
 		"prettier",
 	],
 	parserOptions: {
+		ecmaVersion: 2020,
 		sourceType: "module",
 		ecmaFeatures: {
 			impliedStrict: true,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
         if: github.event.pull_request.draft == false
         strategy:
             matrix:
-                node-version: [12, 14, 16]
+                node-version: [14, 16]
                 os: [macos-latest, ubuntu-latest, windows-latest]
         runs-on: ${{ matrix.os }}
         steps:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "author": "Frazer Smith <frazer.smith@ydh.nhs.uk>",
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "scripts": {
     "benchmark": "autocannon \"http://0.0.0.0:8204/redirect?patient=https://fhir.nhs.uk/Id/nhs-number|9449304513&birthdate=1934-10-23&location=https://fhir.nhs.uk/Id/ods-organization-code|RA4&practitioner=https://sider.nhs.uk/auth|frazer.smith@ydh.nhs.uk\"",


### PR DESCRIPTION
BREAKING CHANGE: minimum required version of node increased from 12 to 14 to allow for new ECMAScript syntax to be used