### PR TITLE
chore(routes/docs)!: rename `docs/json` to `docs/openapi`

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ As an example, providing `birthdate` in an invalid date format will return the f
 
 #### OpenAPI Specification
 
-The OpenAPI v3.x.x specification for this service is found at http://0.0.0.0:8204/docs/json.
+The OpenAPI v3.x.x specification for this service is found at `/docs/openapi`.
 
 ### Deploying Using Docker
 

--- a/src/routes/docs/openapi/index.js
+++ b/src/routes/docs/openapi/index.js
@@ -1,7 +1,7 @@
 // Import plugins
 const cors = require("fastify-cors");
 
-const { docsJsonGetSchema } = require("./schema");
+const { docsOpenapiGetSchema } = require("./schema");
 
 /**
  * @author Frazer Smith
@@ -22,11 +22,11 @@ async function route(server, options) {
 	server.route({
 		method: "GET",
 		url: "/",
-		schema: docsJsonGetSchema,
+		schema: docsOpenapiGetSchema,
 		preValidation: async (req, res) => {
 			if (
 				// Catch unsupported Accept header media types
-				!req.accepts().type(docsJsonGetSchema.produces)
+				!req.accepts().type(docsOpenapiGetSchema.produces)
 			) {
 				throw res.notAcceptable();
 			}

--- a/src/routes/docs/openapi/route.test.js
+++ b/src/routes/docs/openapi/route.test.js
@@ -6,7 +6,7 @@ const route = require(".");
 const getConfig = require("../../../config");
 const sharedSchemas = require("../../../plugins/shared-schemas");
 
-describe("JSON Route", () => {
+describe("OpenAPI Route", () => {
 	describe("GET Requests", () => {
 		let config;
 		let server;

--- a/src/routes/docs/openapi/schema.js
+++ b/src/routes/docs/openapi/schema.js
@@ -4,13 +4,13 @@ const S = require("fluent-json-schema");
  * Fastify uses AJV for JSON Schema Validation,
  * see https://www.fastify.io/docs/latest/Validation-and-Serialization/
  *
- * This validation protects against XSS and HPP attacks.
+ * Input validation protects against XSS, HPP, and most injection attacks.
  */
-const docsJsonGetSchema = {
+const docsOpenapiGetSchema = {
 	hide: true,
 	summary: "List OpenAPI specification",
-	description: "Retrieves OpenAPI specification in JSON format.",
-	operationId: "getDocsJson",
+	description: "Retrieves OpenAPI specification.",
+	operationId: "getDocsOpenapi",
 	produces: ["application/json"],
 	response: {
 		406: S.ref("responses#/definitions/notAcceptable").description(
@@ -25,4 +25,4 @@ const docsJsonGetSchema = {
 	},
 };
 
-module.exports = { docsJsonGetSchema };
+module.exports = { docsOpenapiGetSchema };


### PR DESCRIPTION
BREAKING CHANGE: `docs/json` route renamed to `docs/openapi`